### PR TITLE
Add ym_playnote proc to sound bank

### DIFF
--- a/audio/fm.s
+++ b/audio/fm.s
@@ -103,7 +103,7 @@ success:
 		adc	#$28 ; register for the selected voice
 		tax
 		lda	r0L
-    jsr ym_write
+	jsr ym_write
 	
 	; turn off any playing note
 		ldx #$08	; key on/off register

--- a/audio/test.s
+++ b/audio/test.s
@@ -1,11 +1,12 @@
 .export patches_lo, patches_hi
 
-.import ym_write, ym_loadpatch, ym_loadpatch_rom
+.import ym_write, ym_loadpatch, ym_loadpatch_rom, ym_playnote
 
 .segment "API"
     jmp ym_write
     jmp ym_loadpatch
     jmp ym_loadpatch_rom
+    jmp ym_playnote
 
 .segment "PATCHDATA"
 fm_patches:


### PR DESCRIPTION
This adds a simplified version of the proposed ym_playnote call.  Currently, it does not do any lookup of the note/octave, but instead writes the note argument (passed in X) directly to the YM register.